### PR TITLE
Fix #65: Add StoryRoute - OpenAI-powered travel storytelling app

### DIFF
--- a/section/applications.md
+++ b/section/applications.md
@@ -426,6 +426,7 @@
 1. [Meetily](https://github.com/Zackriya-Solutions/meeting-minutes): Open source Ai Assistant for taking meeting notes [Dec 2024] ![**github stars**](https://img.shields.io/github/stars/Zackriya-Solutions/meeting-minutes?style=flat&label=%20&color=f0f1f2&cacheSeconds=360000)
 1. [Postiz](https://github.com/gitroomhq/postiz-app): AI social media scheduling tool. An alternative to: Buffer.com, Hypefury, Twitter Hunter. [Jul 2023] ![**github stars**](https://img.shields.io/github/stars/gitroomhq/postiz-app?style=flat&label=%20&color=f0f1f2&cacheSeconds=360000)
 1. [Riona-AI-Agent](https://github.com/David-patrick-chuks/Riona-AI-Agent): automation tool designed for Instagram to automate social media interactions such as posting, liking, and commenting. [Jan 2025] ![**github stars**](https://img.shields.io/github/stars/David-patrick-chuks/Riona-AI-Agent?style=flat&label=%20&color=f0f1f2&cacheSeconds=360000)
+1. [StoryRoute](https://github.com/samirk08/storyroute): OpenAI-powered web app that generates immersive, personalized travel narratives, cultural insights, and route recommendations for any destination. [2024] ![**github stars**](https://img.shields.io/github/stars/samirk08/storyroute?style=flat&label=%20&color=f0f1f2&cacheSeconds=360000)
 
 ###### Data, Finance & Analytics
 


### PR DESCRIPTION
Closes #65

Adds StoryRoute to `section/applications.md` (line ~429) in the Social Media & Messaging block, alongside Meetily, Postiz, and Riona-AI-Agent. The entry links to `github.com/samirk08/storyroute`, describes it as an OpenAI-powered web app generating personalized travel narratives and route recommendations, and includes the standard GitHub stars badge with `cacheSeconds=360000`.

- `section/applications.md`: one list item inserted, following the established `1. [Name](url): description. [date] ![stars-badge]` format.

Verified by reviewing the rendered Markdown locally to confirm the new entry's link, badge syntax, and alphabetical placement are consistent with surrounding entries.

---
*This PR was created with AI assistance (Claude). The changes were reviewed by quality gates and a critic model before submission.*