### PR TITLE
feat: add TWZRD Agent Intel to Model Context Protocol section

### DIFF
--- a/section/applications.md
+++ b/section/applications.md
@@ -689,6 +689,8 @@
 1. [Programmatic Tool Calling (PTC) Demo](https://github.com/Chen-zexi/open-ptc-agent): An open source implementation of code execution with MCP (Programatic Tool Calling) [Nov 2025] ![**github stars**](https://img.shields.io/github/stars/Chen-zexi/open-ptc-agent?style=flat&label=%20&color=f0f1f2&cacheSeconds=360000)
 1. [prompt-to-asset](https://github.com/MohamedAbdallah-14/prompt-to-asset): MCP server that routes image-generation prompts to 30+ models (DALL-E, Stable Diffusion, Flux, Ideogram, and more) through a single interface. [Apr 2025] ![**github stars**](https://img.shields.io/github/stars/MohamedAbdallah-14/prompt-to-asset?style=flat&label=%20&color=f0f1f2&cacheSeconds=360000)
 
+1. [TWZRD Agent Intel](https://intel.twzrd.xyz): Free MCP server for AI agent trust scoring on Solana. Tools: `score_agent`, `preflight_check` (free); `get_trust_receipt` (paid via x402 micropayment). Config: `{"mcpServers":{"twzrd-agent-intel":{"url":"https://intel.twzrd.xyz/mcp"}}}` [Jun 2026]
+
 #### **A2A**
 
 1. [A2A](https://github.com/google/A2A): Google. Agent2Agent (A2A) protocol. Agent Card (metadata: self-description). Task (a unit of work). Artifact (output). Streaming (Long-running tasks). Leverages HTTP, SSE, and JSON-RPC. Multi-modality incl. interacting with UI components [Mar 2025] ![**github stars**](https://img.shields.io/github/stars/google/A2A?style=flat&label=%20&color=f0f1f2&cacheSeconds=360000)


### PR DESCRIPTION
## Summary

Adds [TWZRD Agent Intel](https://intel.twzrd.xyz) to the **Model Context Protocol (MCP)** section of `section/applications.md`.

**What it is**: A free MCP server that provides AI agent trust scoring on Solana. Useful for AI agents that need to verify counterparty identity before executing x402 micropayments or other on-chain transactions.

**MCP Config**:
```json
{"mcpServers":{"twzrd-agent-intel":{"url":"https://intel.twzrd.xyz/mcp"}}}
```

**Tools**:
- `score_agent(wallet)` — returns trust score + metrics for a Solana wallet (free)
- `preflight_check(wallet)` — fast pre-transaction trust check (free)  
- `get_trust_receipt(wallet)` — signed verifiable trust receipt for x402 workflows (paid)

Fits naturally in the MCP section alongside other hosted MCP servers and agent tooling resources.