### PR TITLE
docs: add Agent QA to LLMOps

### DIFF
--- a/section/tools_extra.md
+++ b/section/tools_extra.md
@@ -270,6 +270,7 @@ databricks-dolly-15k: Instruction-Tuned [🤗](https://huggingface.co/datasets/d
 
 ## **LLMOps: Large Language Model Operations**
 
+- [Agent QA](https://github.com/vostride/agent-qa): The self-improving QA agent for software teams, with natural-language web/mobile regression tests and persistent test memory. [May 2026] ![**github stars**](https://img.shields.io/github/stars/vostride/agent-qa?style=flat&label=%20&color=f0f1f2&cacheSeconds=360000)
 - [Agent Trace](https://agent-trace.dev/): Data spec for recording AI agent attribution, reasoning steps, and tool calls.
 - [agenta](https://github.com/Agenta-AI/agenta): OSS LLMOps workflow: building (LLM playground, evaluation), deploying (prompt and configuration management), and monitoring (LLM observability and tracing). [Jun 2023] ![**github stars**](https://img.shields.io/github/stars/Agenta-AI/agenta?style=flat&label=%20&color=f0f1f2&cacheSeconds=360000)
 - [Azure ML Prompt flow](https://microsoft.github.io/promptflow/index.html): A set of LLMOps tools designed to facilitate the creation of LLM-based AI applications [Sep 2023] > [How to Evaluate & Upgrade Model Versions in the Azure OpenAI Service](https://techcommunity.microsoft.com/t5/ai-azure-ai-services-blog/how-to-evaluate-amp-upgrade-model-versions-in-the-azure-openai/ba-p/4218880) [14 Aug 2024]


### PR DESCRIPTION
## Summary

Add Agent QA to the LLMOps resource section with the repository's date and live GitHub-star badge format.

## Why it fits

[Agent QA](https://github.com/vostride/agent-qa) is a black-box QA agent for natural-language web and mobile regression tests. It retains scoped product, suite, and test observations between runs, so it can complement the evaluation and operational tooling already cataloged in this section by exercising complete user journeys through a deployed LLM application.

Agent QA has no native Azure or Azure OpenAI integration, and this entry does not imply one. It is a general external application-testing companion that can be used around an Azure-hosted application through its user-facing interface.

The `[May 2026]` date reflects the source repository's creation month. The current FSL-1.1-ALv2 license is source-available rather than OSI open source and converts to Apache-2.0 after two years. I am affiliated with Vostride and Agent QA.

## Validation

- `git diff --check` passes.
- The canonical repository URL and shields.io star badge resolve correctly.
- The README links directly to the edited LLMOps section.
- The README, section file, issues, and pull requests contain no existing Agent QA entry or proposal.
- The content change is one list item; the edit also normalizes the section file's missing final newline.
